### PR TITLE
Git: fix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,219 @@
+# Based on FPS-sample: https://github.com/Unity-Technologies/FPSSample
+# Organized+extended by Lex-DRL: https://github.com/Lex-DRL/git-template-gamedev
+
+# Auto-detect text/binary by default:
+* 	text=auto eol=lf
+
+# raw-Text files
+*.[Cc][Ss][Vv] text
+*.[Mm][Dd] text diff=markdown
+*.[Tt][Xx][Tt] text
+
+# Checksums
+*.[Mm][Dd]5 text
+*.[Ss][Hh][Aa] text
+*.[Ss][Hh][Aa][0123456789]* text
+
+# Scripts: OS
+*.[Bb][Aa][Tt] text
+*.[Cc][Mm][Dd] text
+*.[Pp][Ll] text
+*.[Pp][Ss]1 text
+*.[Ss][Hh] text diff=bash
+
+# Scripts: Python
+*.[Pp][Yy] text diff=python
+
+# Scripts: Other programming languages
+*.[Cc][Ss] text diff=csharp
+*.[Cc][Ss][Ss] text diff=css
+*.[Hh] text diff=cpp
+*.[Hh][Tt][Mm] text diff=html
+*.[Hh][Tt][Mm][Ll] text diff=html
+*.[Jj][Ss] text
+*.[Jj][Ss][Oo][Nn] text
+*.[Pp][Hh][Pp] text diff=php
+*.[Ss][Qq][Ll] text=auto eol=lf
+*.[Xx][Mm][Ll] text diff=html
+*.[Xx][Hh][Tt][Mm][Ll] text diff=html
+*.[Yy][Aa][Mm][Ll] text
+*.[Yy][Mm][Ll] text
+
+# Vector graphics
+*.[Ss][Vv][Gg] text
+
+
+# -----------------------------------------------
+# Unity-related: text
+# -----------------------------------------------
+*.asset text=auto eol=lf
+*.meta text merge=unityyamlmerge
+
+# Shading
+*.cginc text
+*.compute text
+*.giparams text
+*.glsl text
+*.hlsl text
+*.hlslinc text
+*.mat text
+*.shader text
+*.[Ss]hader[Vv]ariants text
+*.[Ss]hader[Gg]raph text
+
+# Physics
+*.[Pp]hysic[Mm]aterial text
+*.[Pp]hysic[Mm]aterial[23][Dd] text
+
+# Other Unity's text files
+*.anim text
+*.asmdef text
+*.controller text
+*.guiskin text
+*.mask text
+*.mixer text
+*.[Oo]verride[Cc]ontroller text
+*.playable text
+*.prefab text merge=unityyamlmerge
+*.[Ss]prite[Aa]tlas text
+*.unity text merge=unityyamlmerge
+
+
+# -----------------------------------------------
+# Unity-related: binary
+# -----------------------------------------------
+*.entities binary
+*.bundle binary
+*.unitypackage binary
+
+
+# -----------------------------------------------
+# DCC software (CG/VFX): text/binary
+# -----------------------------------------------
+
+# 2D: Adobe Illustrator:
+*.[Aa][Ii] text=auto eol=lf
+
+# Audio production:
+*.[Rr][Nn][Ss] binary
+*.[Rr][Ee][Aa][Ss][Oo][Nn] binary
+*.[Ss][Ee][Ss][Xx] text diff=html
+
+# 3D: Cross-package / Geometry:
+# Geo-files might be in text format, but most of the time they're too big anyway:
+*.[Ff][Bb][Xx] text=auto eol=lf
+*.[Oo][Bb][Jj] text=auto eol=lf
+
+# Blender
+*.[Bb][Ll][Ee][Nn][Dd] binary
+
+# Foundry Nuke:
+*.[Gg][Ii][Zz][Mm][Oo] text
+*.[Nn][Kk] text
+
+# Foundry Modo:
+*.[Ll][Xx][Oo] binary
+
+# Houdini:
+*.[Oo][Tt][Ll] binary
+*.[Hh][Dd][Aa] binary
+*.[Bb][Gg][Ee][Oo] binary
+*.[Bb][Gg][Ee][Oo].* binary
+*.[Gg][Ee][Oo] binary
+*.[Gg][Ee][Oo].* binary
+
+# Maya
+*.[Mm][Aa] text=auto eol=lf
+*.[Mm][Bb] binary
+*.[Mm][Ee][Ll] text
+
+# Substance:
+*.[Ss][Bb][Ss][Aa][Rr] text=auto eol=lf
+
+
+# =========================================================================== #
+# 	Common binary formats
+# =========================================================================== #
+
+# For LFS: replace "binary" to "filter=lfs diff=lfs merge=lfs -text"
+
+*.[Dd][Bb] binary
+*.[Mm][Dd][Bb] binary
+*.[Pp][Dd][Tt] binary
+
+# Android/Java
+*.[AaJj][Aa][Rr] binary
+*.[Aa][Pp][Kk] binary
+
+# Archives
+*.7[Zz] binary
+*.[Gg][Zz] binary
+*.[Zz][Ii][Pp] binary
+*.[RrTt][Aa][Rr] binary
+
+# Python binaries:
+*.[Pp][Yy][CcDdOo] binary
+*.[Pp][Dd][Bb] binary
+*.[Ww][Hh][Ll] binary
+
+# OS libraries / Executables / Software dev
+*.[Aa] binary
+*.[Bb][Yy][Tt][Ee][Ss] binary
+*.[Dd][Ll][Ll] binary
+*.[Ee][Xx][Ee] binary
+*.[Ll][Ii][Bb] binary
+*.[NnXx][Ii][Bb] binary
+*.[Ss][Oo] binary
+*.[Ss][Yy][Ss] binary
+
+# Fonts
+*.[Ee][Oo][Tt] binary
+*.[OoTt][Tt][Ff] binary
+*.[Ww][Oo][Ff][Ff] binary
+*.[Ww][Oo][Ff][Ff]2 binary
+
+# Images: HDR
+*.[Ee][Xx][Rr] binary
+*.[Hh][Dd][Rr] binary
+*.[Tt][Ii][Ff] binary
+*.[Tt][Ii][Ff][Ff] binary
+
+# Images: Primary
+*.[Bb][Mm][Pp] binary
+*.[Gg][Ii][Ff] binary
+*.[Jj][Pp][Gg] binary
+*.[Jj][Pp][Ee][Gg] binary
+*.[Pp][Nn][Gg] binary
+*.[Tt][Gg][Aa] binary
+
+# Images: Other
+*.[Cc][Uu][Rr] binary
+*.[Ii][Cc][Nn][Ss] binary
+*.[Ii][Cc][OoNn] binary
+*.[Ii][Cc][Oo][Nn] binary
+*.[Pp][Dd][Ff] binary
+*.[Pp][Ss][DdBb] binary
+
+# Audio
+*.[Aa][Aa][Cc] binary
+*.[AaFf][Ll][Aa][Cc] binary
+*.[Aa][Ii][Ff] binary
+*.[Cc][Aa][Ff] binary
+*.[Mm]4[Aa] binary
+*.[Mm][Pp][1234] binary
+*.[Oo][Gg][GgAa] binary
+*.[Ww][Aa][Vv] binary
+
+# Video
+# mp4 caught by audio pattern
+*.[Aa][Vv][Ii] binary
+*.[Bb][Ii][Kk] binary
+*.[Mm][KkOo][Vv] binary
+*.[Oo][Gg][VvXx] binary
+*.[Ss][Ww][Ff] binary
+
+
+# =========================================================================== #
+# 	Repo-specific
+# =========================================================================== #
+# add here

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.meta
+*.asset


### PR DESCRIPTION
This PR forcefully sets line-endings to be unix-style on all text files + specifies some common binary/text rules for a Unity project.

# ATTENTION:
To actually fix the line endings, you need to manually do two separate commits afterwards:
- Remove all the files
- Re-commit them again (as a separate commit, this is important)

This is the only way to fix line ending inconsistencies in a git repo. And this is the reason why a `.gitattributes` should be committed at the very start of a new repo, before any actual files.